### PR TITLE
Ignore .mvn and out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,11 @@
 hs_err_pid*
 *.iml
 *.idea/
+*.mvn/
 
 classes/
 target/
 build/
+out/
 
 .DS_Store


### PR DESCRIPTION
I found that someone may push those two directories. But actually, we don't need them. So I put them into .gitignore file.